### PR TITLE
dashboard-screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { IonApp, IonRouterOutlet, setupIonicReact } from "@ionic/react";
 import { IonReactRouter } from "@ionic/react-router";
 import Home from "./pages/Home";
 import ViewMessage from "./pages/ViewMessage";
+import Dashboard from "./pages/Dashboard";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
@@ -36,6 +37,9 @@ const App: React.FC = () => (
         <IonRouterOutlet>
           <Route path="/" exact={true}>
             <Redirect to="/dashboard" />
+          </Route>
+          <Route path="/dashboard" exact={true}>
+            <Dashboard />
           </Route>
           <Route path="/home" exact={true}>
             <Home />

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,28 @@
+import { 
+  IonCard,
+  IonImg, 
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent
+} from '@ionic/react';
+import { Project } from '../data/projects';
+
+interface ProjectCardProps {
+  project: Project;
+}
+
+const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
+  return (
+    <IonCard color='white'>
+      <IonImg src={project.imageUrl} />
+        <IonCardHeader>
+          <IonCardTitle>{project.title}</IonCardTitle>
+        </IonCardHeader>
+        <IonCardContent>
+          {project.description}
+        </IonCardContent>
+      </IonCard>
+  );
+}; 
+
+export default ProjectCard;

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,58 @@
+export interface Project {
+  id: number;
+  imageUrl: string;
+  title: string;
+  description: string;
+}
+
+export const projects: Project[] = [
+  {
+    title: 'Matt Chorsey',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 0
+  },
+  {
+    title: 'Lauren Ruthford',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 1
+  },
+  {
+    title: 'Jordan Firth',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 2
+
+  },
+  {
+    title: 'Bill Thomas',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 3
+  },
+  {
+    title: 'Joanne Pollan',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 4
+  },
+  {
+    title: 'Andrea Cornerston',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 5
+  },
+  {
+    title: 'Moe Chamont',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 6
+  },
+  {
+    title: 'Kelly Richardson',
+    imageUrl: 'https://www.linkpicture.com/q/mansion.jpg',
+    description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book",
+    id: 7
+  }
+];

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {
+  IonContent
+} from '@ionic/react';
+import ProjectCard from '../components/ProjectCard';
+import { projects } from '../data/projects';
+
+const Dashboard: React.FC = () => {
+  return (
+    <IonContent fullscreen>
+      {projects.map((project) => (
+        <ProjectCard key={project.id} project={project} />
+      ))}
+    </IonContent>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
Dashboard Screen
**Why we have this PR:**
- Making a new default page called `dashboard` and show all the projects from static data as a card item.

**How to test:**
- Run the app with `ionic serve` command.
- It will automatically route `/` to `/dashboard`.
- The dashboard screen must show all the projects from static data as a card item and can be scrolling to the end.

**Tested on:**
- [x] Web
- [x] Android
- [x] iOS
