### PR TITLE
create-new-project-screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ const App: React.FC = () => (
           <Route path="/dashboard" component={Dashboard} />
           <Redirect exact from="/" to="/dashboard" />
 
-          <Route path="/createProject" component={CreateProject} />
+          <Route exact path="/createProject" component={CreateProject} />
 
           <Route path="/home" exact={true}>
             <Home />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { IonReactRouter } from "@ionic/react-router";
 import Home from "./pages/Home";
 import ViewMessage from "./pages/ViewMessage";
 import Dashboard from "./pages/Dashboard";
+import CreateProject from "./pages/CreateProject";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
@@ -37,15 +38,15 @@ const App: React.FC = () => (
     <IonApp>
       <IonReactRouter>
         <IonRouterOutlet>
-          <Route path="/" exact={true}>
-            <Redirect to="/dashboard" />
-          </Route>
-          <Route path="/dashboard" exact={true}>
-            <Dashboard />
-          </Route>
+          <Route path="/dashboard" component={Dashboard} />
+          <Redirect exact from="/" to="/dashboard" />
+
+          <Route path="/createProject" component={CreateProject} />
+
           <Route path="/home" exact={true}>
             <Home />
           </Route>
+
           <Route path="/message/:id">
             <ViewMessage />
           </Route>

--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   IonContent,
   IonToolbar,
@@ -11,49 +11,58 @@ import {
   IonInput,
   IonList,
   IonTextarea,
-  IonButton
-} from '@ionic/react';
+  IonButton,
+  IonPage,
+} from "@ionic/react";
 
 const CreateProject: React.FC = () => {
   const [projectName, setProjectName] = useState<string>();
   const [projectDescription, setProjectDescription] = useState<string>();
   return (
-    <IonContent fullscreen>
-      <IonHeader translucent>
+    <IonPage>
+      <IonHeader>
         <IonToolbar>
           <IonTitle>Project Tracker</IonTitle>
 
-          <IonButtons slot='end'>
-            <IonButton onClick={() => {
-                console.log('🚀 ~ projectName', projectName)
-                console.log('🚀 ~ projectDescription', projectDescription)
-              }}>
-                Create
+          <IonButtons slot="end">
+            <IonButton
+              onClick={() => {
+                console.log("🚀 ~ projectName", projectName);
+                console.log("🚀 ~ projectDescription", projectDescription);
+              }}
+            >
+              Create
             </IonButton>
           </IonButtons>
 
-          <IonButtons slot='start'>
-            <IonBackButton defaultHref='/'/>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="\" />
           </IonButtons>
         </IonToolbar>
       </IonHeader>
 
-      <IonList class='ion-margin'>
-        <IonItem>
-          <IonLabel position='stacked'>Project's name</IonLabel>
-          <IonInput 
-            value={projectName}
-            onIonChange={event => setProjectName(event.detail.value!)}></IonInput>
-        </IonItem>
-        <IonItem>
-          <IonLabel position='stacked'>Project's Description</IonLabel>
-          <IonTextarea 
-            auto-grow value={projectDescription}
-            onIonChange={event => setProjectDescription(event.detail.value!)}>
-          </IonTextarea>
-        </IonItem>
-      </IonList>
-    </IonContent>
+      <IonContent fullscreen>
+        <IonList class="ion-margin">
+          <IonItem>
+            <IonLabel position="stacked">Project's name</IonLabel>
+            <IonInput
+              value={projectName}
+              onIonChange={(event) => setProjectName(event.detail.value || "")}
+            ></IonInput>
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Project's Description</IonLabel>
+            <IonTextarea
+              auto-grow
+              value={projectDescription}
+              onIonChange={(event) =>
+                setProjectDescription(event.detail.value!)
+              }
+            ></IonTextarea>
+          </IonItem>
+        </IonList>
+      </IonContent>
+    </IonPage>
   );
 };
 

--- a/src/pages/CreateProject.tsx
+++ b/src/pages/CreateProject.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import {
+  IonContent,
+  IonToolbar,
+  IonButtons,
+  IonTitle,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonBackButton,
+  IonInput,
+  IonList,
+  IonTextarea,
+  IonButton
+} from '@ionic/react';
+
+const CreateProject: React.FC = () => {
+  const [projectName, setProjectName] = useState<string>();
+  const [projectDescription, setProjectDescription] = useState<string>();
+  return (
+    <IonContent fullscreen>
+      <IonHeader translucent>
+        <IonToolbar>
+          <IonTitle>Project Tracker</IonTitle>
+
+          <IonButtons slot='end'>
+            <IonButton onClick={() => {
+                console.log('🚀 ~ projectName', projectName)
+                console.log('🚀 ~ projectDescription', projectDescription)
+              }}>
+                Create
+            </IonButton>
+          </IonButtons>
+
+          <IonButtons slot='start'>
+            <IonBackButton defaultHref='/'/>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+
+      <IonList class='ion-margin'>
+        <IonItem>
+          <IonLabel position='stacked'>Project's name</IonLabel>
+          <IonInput 
+            value={projectName}
+            onIonChange={event => setProjectName(event.detail.value!)}></IonInput>
+        </IonItem>
+        <IonItem>
+          <IonLabel position='stacked'>Project's Description</IonLabel>
+          <IonTextarea 
+            auto-grow value={projectDescription}
+            onIonChange={event => setProjectDescription(event.detail.value!)}>
+          </IonTextarea>
+        </IonItem>
+      </IonList>
+    </IonContent>
+  );
+};
+
+export default CreateProject;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import {
-  IonContent
+  IonContent,
+  IonToolbar,
+  IonButtons,
+  IonTitle,
+  IonHeader,
+  IonLabel,
+  IonButton
 } from '@ionic/react';
 import ProjectCard from '../components/ProjectCard';
 import { projects } from '../data/projects';
@@ -8,6 +14,18 @@ import { projects } from '../data/projects';
 const Dashboard: React.FC = () => {
   return (
     <IonContent fullscreen>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Project Tracker</IonTitle>
+
+          <IonButtons slot='end'>
+            <IonButton routerLink='/createProject'>
+                <IonLabel>Create</IonLabel>
+            </IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+    
       {projects.map((project) => (
         <ProjectCard key={project.id} project={project} />
       ))}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import {
   IonContent,
   IonToolbar,
@@ -6,30 +6,33 @@ import {
   IonTitle,
   IonHeader,
   IonLabel,
-  IonButton
-} from '@ionic/react';
-import ProjectCard from '../components/ProjectCard';
-import { projects } from '../data/projects';
+  IonButton,
+  IonPage,
+} from "@ionic/react";
+import ProjectCard from "../components/ProjectCard";
+import { projects } from "../data/projects";
 
 const Dashboard: React.FC = () => {
   return (
-    <IonContent fullscreen>
+    <IonPage>
       <IonHeader>
         <IonToolbar>
           <IonTitle>Project Tracker</IonTitle>
 
-          <IonButtons slot='end'>
-            <IonButton routerLink='/createProject'>
-                <IonLabel>Create</IonLabel>
+          <IonButtons slot="end">
+            <IonButton routerLink="/createProject">
+              <IonLabel>Create</IonLabel>
             </IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>
-    
-      {projects.map((project) => (
-        <ProjectCard key={project.id} project={project} />
-      ))}
-    </IonContent>
+
+      <IonContent fullscreen>
+        {projects.map((project) => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </IonContent>
+    </IonPage>
   );
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import MessageListItem from "../components/MessageListItem";
 import { useState } from "react";
 import { Message, getMessages } from "../data/messages";
 import {
+  IonBackButton,
+  IonButtons,
   IonContent,
   IonHeader,
   IonItem,
@@ -37,6 +39,9 @@ const Home: React.FC = () => {
     <IonPage id="home-page">
       <IonHeader>
         <IonToolbar>
+          <IonButtons>
+            <IonBackButton />
+          </IonButtons>
           <IonTitle>Inbox</IonTitle>
         </IonToolbar>
       </IonHeader>


### PR DESCRIPTION
**Why we have this PR:**
- Page for creating a new project

**How to test:**
- From the main screen (dashboard), click/touch on the `Create` button
- Fill 2 input fields: Project's name and Project's description, press `Create` button to see if the value can be logged on the console 
- Press the `Back` button to go back to the previous screen.
**Tested on:**
- [x] Web
- [x] Android
- [x] iOS
