### PR TITLE
Adding steps page for each project

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.vscode
+package.json
+*.htm

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "tabWidth": 2
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,37 @@
-import { Redirect, Route } from "react-router-dom";
-import { IonApp, IonRouterOutlet, setupIonicReact } from "@ionic/react";
-import { IonReactRouter } from "@ionic/react-router";
-import Home from "./pages/Home";
-import ViewMessage from "./pages/ViewMessage";
-import Dashboard from "./pages/Dashboard";
-import CreateProject from "./pages/CreateProject";
+import { Redirect, Route } from 'react-router-dom';
+import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
+import { IonReactRouter } from '@ionic/react-router';
+import Home from './pages/Home';
+import ViewMessage from './pages/ViewMessage';
+import Dashboard from './pages/Dashboard';
 
 /* Core CSS required for Ionic components to work properly */
-import "@ionic/react/css/core.css";
+import '@ionic/react/css/core.css';
 
 /* Basic CSS for apps built with Ionic */
-import "@ionic/react/css/normalize.css";
-import "@ionic/react/css/structure.css";
-import "@ionic/react/css/typography.css";
+import '@ionic/react/css/normalize.css';
+import '@ionic/react/css/structure.css';
+import '@ionic/react/css/typography.css';
 
 /* Optional CSS utils that can be commented out */
-import "@ionic/react/css/padding.css";
-import "@ionic/react/css/float-elements.css";
-import "@ionic/react/css/text-alignment.css";
-import "@ionic/react/css/text-transformation.css";
-import "@ionic/react/css/flex-utils.css";
-import "@ionic/react/css/display.css";
+import '@ionic/react/css/padding.css';
+import '@ionic/react/css/float-elements.css';
+import '@ionic/react/css/text-alignment.css';
+import '@ionic/react/css/text-transformation.css';
+import '@ionic/react/css/flex-utils.css';
+import '@ionic/react/css/display.css';
 
 /* Theme variables */
-import "./theme/variables.css";
+import './theme/variables.css';
 /* Tailwind variables */
-import "./theme/tailwind.css";
-import { Provider } from "react-redux";
-import { store } from "./app/store";
+import './theme/tailwind.css';
+import { Provider } from 'react-redux';
+import { store } from './app/store';
+import Steps from './pages/Steps';
+import CreateProject from './pages/CreateProject';
 
 setupIonicReact({
-  mode: "ios",
+  mode: 'ios',
 });
 
 const App: React.FC = () => (
@@ -39,17 +40,20 @@ const App: React.FC = () => (
       <IonReactRouter>
         <IonRouterOutlet>
           <Route path="/dashboard" component={Dashboard} />
-          <Redirect exact from="/" to="/dashboard" />
 
           <Route exact path="/createProject" component={CreateProject} />
 
-          <Route path="/home" exact={true}>
+          <Route exact path="/home">
             <Home />
           </Route>
-
+          <Route exact path="/steps">
+            <Steps />
+          </Route>
           <Route path="/message/:id">
             <ViewMessage />
           </Route>
+
+          <Redirect exact from="/" to="/dashboard" />
         </IonRouterOutlet>
       </IonReactRouter>
     </IonApp>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,8 @@ import { Provider } from 'react-redux';
 import { store } from './app/store';
 import Steps from './pages/Steps';
 import CreateProject from './pages/CreateProject';
-import { DASHBOARD_PAGE, STEPS_PAGE } from './app/routes';
+import { DASHBOARD_PAGE, GALLERY_PAGE, STEPS_PAGE } from './app/routes';
+import Gallery from './pages/Gallery';
 
 setupIonicReact({
   mode: 'ios',
@@ -45,8 +46,14 @@ const App: React.FC = () => (
           <Route exact path="/home">
             <Home />
           </Route>
+          <Route exact path={DASHBOARD_PAGE}>
+            <Dashboard />
+          </Route>
           <Route exact path={STEPS_PAGE}>
             <Steps />
+          </Route>
+          <Route exact path={GALLERY_PAGE}>
+            <Gallery />
           </Route>
           <Route path="/message/:id">
             <ViewMessage />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { Provider } from 'react-redux';
 import { store } from './app/store';
 import Steps from './pages/Steps';
 import CreateProject from './pages/CreateProject';
+import { DASHBOARD_PAGE, STEPS_PAGE } from './app/routes';
 
 setupIonicReact({
   mode: 'ios',
@@ -39,21 +40,19 @@ const App: React.FC = () => (
     <IonApp>
       <IonReactRouter>
         <IonRouterOutlet>
-          <Route path="/dashboard" component={Dashboard} />
-
+          <Route exact path={DASHBOARD_PAGE} component={Dashboard} />
           <Route exact path="/createProject" component={CreateProject} />
-
           <Route exact path="/home">
             <Home />
           </Route>
-          <Route exact path="/steps">
+          <Route exact path={STEPS_PAGE}>
             <Steps />
           </Route>
           <Route path="/message/:id">
             <ViewMessage />
           </Route>
 
-          <Redirect exact from="/" to="/dashboard" />
+          <Redirect exact from="/" to={DASHBOARD_PAGE} />
         </IonRouterOutlet>
       </IonReactRouter>
     </IonApp>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,2 +1,3 @@
 export const STEPS_PAGE = '/steps';
 export const DASHBOARD_PAGE = '/dashboard';
+export const GALLERY_PAGE = '/gallery';

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,0 +1,2 @@
+export const STEPS_PAGE = '/steps';
+export const DASHBOARD_PAGE = '/dashboard';

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import { IonCard, IonImg, IonCardHeader, IonCardTitle, IonCardContent } from '@ionic/react';
+import { STEPS_PAGE } from '../app/routes';
 import { Project } from '../data/projects';
 
 interface ProjectCardProps {
@@ -6,7 +7,7 @@ interface ProjectCardProps {
 }
 
 const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
-  <IonCard color="white" routerLink="/steps">
+  <IonCard color="white" routerLink={STEPS_PAGE}>
     <IonImg src={project.imageUrl} />
     <IonCardHeader>
       <IonCardTitle>{project.title}</IonCardTitle>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,28 +1,18 @@
-import { 
-  IonCard,
-  IonImg, 
-  IonCardHeader,
-  IonCardTitle,
-  IonCardContent
-} from '@ionic/react';
+import { IonCard, IonImg, IonCardHeader, IonCardTitle, IonCardContent } from '@ionic/react';
 import { Project } from '../data/projects';
 
 interface ProjectCardProps {
   project: Project;
 }
 
-const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
-  return (
-    <IonCard color='white'>
-      <IonImg src={project.imageUrl} />
-        <IonCardHeader>
-          <IonCardTitle>{project.title}</IonCardTitle>
-        </IonCardHeader>
-        <IonCardContent>
-          {project.description}
-        </IonCardContent>
-      </IonCard>
-  );
-}; 
+const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => (
+  <IonCard color="white" routerLink="/steps">
+    <IonImg src={project.imageUrl} />
+    <IonCardHeader>
+      <IonCardTitle>{project.title}</IonCardTitle>
+    </IonCardHeader>
+    <IonCardContent>{project.description}</IonCardContent>
+  </IonCard>
+);
 
 export default ProjectCard;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import {
   IonContent,
   IonToolbar,
@@ -8,9 +8,9 @@ import {
   IonLabel,
   IonButton,
   IonPage,
-} from "@ionic/react";
-import ProjectCard from "../components/ProjectCard";
-import { projects } from "../data/projects";
+} from '@ionic/react';
+import ProjectCard from '../components/ProjectCard';
+import { projects } from '../data/projects';
 
 const Dashboard: React.FC = () => {
   return (

--- a/src/pages/Gallery/index.tsx
+++ b/src/pages/Gallery/index.tsx
@@ -1,0 +1,75 @@
+import {
+  IonBackButton,
+  IonButtons,
+  IonCol,
+  IonContent,
+  IonGrid,
+  IonHeader,
+  IonImg,
+  IonPage,
+  IonRow,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+
+const Gallery = () => {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton />
+          </IonButtons>
+          <IonTitle>Gallery</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+
+      <IonContent>
+        <IonGrid>
+          <IonRow>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+          </IonRow>
+          <IonRow>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+          </IonRow>
+          <IonRow>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+          </IonRow>
+          <IonRow>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+          </IonRow>
+          <IonRow>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+            <IonCol>
+              <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+            </IonCol>
+          </IonRow>
+        </IonGrid>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Gallery;

--- a/src/pages/Steps/index.tsx
+++ b/src/pages/Steps/index.tsx
@@ -16,6 +16,7 @@ import {
   IonToolbar,
 } from '@ionic/react';
 import { useCallback, useState } from 'react';
+import { GALLERY_PAGE } from '../../app/routes';
 import './styles.css';
 
 const Steps: React.FC = () => {
@@ -52,7 +53,7 @@ const Steps: React.FC = () => {
         <IonList>
           <IonReorderGroup disabled={!enableReorder} onIonItemReorder={doReorder}>
             {steps.map((step) => (
-              <IonItem key={step}>
+              <IonItem key={step} routerLink={GALLERY_PAGE}>
                 <IonThumbnail slot="start">
                   <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
                 </IonThumbnail>

--- a/src/pages/Steps/index.tsx
+++ b/src/pages/Steps/index.tsx
@@ -1,0 +1,73 @@
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonImg,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPage,
+  IonReorder,
+  IonReorderGroup,
+  IonThumbnail,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/react';
+import { useCallback, useState } from 'react';
+import './styles.css';
+
+const Steps: React.FC = () => {
+  const [enableReorder, setEnableReorder] = useState(false);
+  const [steps, setSteps] = useState(['Step 1', 'Step 2', 'Step 3']);
+
+  const reorderText = enableReorder ? 'Done' : 'Re-order';
+
+  const onToggleReorder = useCallback(() => {
+    setEnableReorder(!enableReorder);
+  }, [setEnableReorder, enableReorder]);
+
+  const doReorder = useCallback(
+    (event: CustomEvent) => {
+      setSteps(event.detail.complete(steps));
+    },
+    [steps],
+  );
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton />
+          </IonButtons>
+          <IonTitle>Steps</IonTitle>
+          <IonButtons slot="end">
+            <IonButton onClick={onToggleReorder}>{reorderText}</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        <IonList>
+          <IonReorderGroup disabled={!enableReorder} onIonItemReorder={doReorder}>
+            {steps.map((step) => (
+              <IonItem key={step}>
+                <IonThumbnail slot="start">
+                  <IonImg src="https://www.linkpicture.com/q/mansion.jpg" />
+                </IonThumbnail>
+                <IonLabel>
+                  <h2>{step}</h2>
+                  <p>Step description</p>
+                </IonLabel>
+                <IonReorder slot="end" />
+              </IonItem>
+            ))}
+          </IonReorderGroup>
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Steps;

--- a/src/pages/Steps/index.tsx
+++ b/src/pages/Steps/index.tsx
@@ -20,7 +20,7 @@ import './styles.css';
 
 const Steps: React.FC = () => {
   const [enableReorder, setEnableReorder] = useState(false);
-  const [steps, setSteps] = useState(['Step 1', 'Step 2', 'Step 3']);
+  const [steps, setSteps] = useState(['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Step 6']);
 
   const reorderText = enableReorder ? 'Done' : 'Re-order';
 


### PR DESCRIPTION
**Why we have this PR:**
- Adding steps screen with re-order function for re-ordering items
- Adding gallery screen for showing images in grid

**How to test:**
- In `dashboard` screen, click on any project to navigate to `steps` screen
- In `steps` screen, click on re-order to re-order items below
- Click on any steps to navigate to `gallery` screen

**Tested on:**
- [x] Web
- [x] Android
- [x] iOS
